### PR TITLE
Adds github action to build and push docker image

### DIFF
--- a/.github/workflows/build-and-push-dockerhub.yml
+++ b/.github/workflows/build-and-push-dockerhub.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check out the repo
+        uses: actions/checkout@v2
+      - 
+        name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set image metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: yadomi/repetier-server
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, 'master') }}
+            type=ref,event=tag
+          flavor: |
+            latest=false
+      -
+        name: Build (and push to Docker hub)
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This Github action should reproduce the same behavior as before with Docker Hub Autobuild service:

- Build and push the image with `latest` when something is merged on `master`
- Build and push the image with `vX.X.X` when a `tag` is pushed

close #13