### PR TITLE
Update Repetier version to 1.4.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ARG VERSION="1.4.14"
+ARG VERSION="1.4.15"
 
 LABEL maintainer="felix.yadomi@gmail.com"
 LABEL version="v${VERSION}"


### PR DESCRIPTION
This PR updates the Repetier Server version to 1.4.15 (latest available).